### PR TITLE
Update Google Search Console

### DIFF
--- a/google_searchconsole/gsc_load_bq.py
+++ b/google_searchconsole/gsc_load_bq.py
@@ -38,8 +38,8 @@ def construct_service_old():
         pe.SERVICE_ACCOUNT_FILE_BQ, scopes=pe.SCOPES)
 
     service = build(
-        'webmasters',
-        'v3',
+        'searchconsole',
+        'v1',
         credentials=credentials
     )
 


### PR DESCRIPTION
The API Name and the Version changed. The old name "webmaster" and the old version "v3" are not working anymore.

Please refer to: https://developers.google.com/search/blog/2020/12/search-console-api-updates?hl=en